### PR TITLE
Update version of requested jQueryUI file

### DIFF
--- a/elfinder/elfinder.php
+++ b/elfinder/elfinder.php
@@ -22,10 +22,10 @@ global $lang;
 $mkup_lang = $cfg['plugins_dir']."/elfinder/js/i18n/elfinder.$lang.js";
 
 // Load resources
-$mkup_skin = cot_rc('code_rc_css_file', array('url' => $cfg['plugins_dir'] . '/elrte/css/smoothness/jquery-ui-1.8.13.custom.css'));
+$mkup_skin = cot_rc('code_rc_css_file', array('url' => $cfg['plugins_dir'] . '/elrte/css/smoothness/jquery-ui-1.8.20.custom.css'));
 $mkup_theme = cot_rc('code_rc_css_file', array('url' => $cfg['plugins_dir'] . '/elfinder/css/elfinder.min.css'));
 $mkup_theme2 = cot_rc('code_rc_css_file', array('url' => $cfg['plugins_dir'] . '/elfinder/css/theme.css'));
-cot_rc_link_footer($cfg['plugins_dir'] . '/elrte/js/jquery-ui-1.8.13.custom.min.js');
+cot_rc_link_footer($cfg['plugins_dir'] . '/elrte/js/jquery-ui-1.8.20.custom.min.js');
 cot_rc_link_footer($cfg['plugins_dir'] . '/elfinder/js/elfinder.min.js');
 if (file_exists($mkup_lang))
 {


### PR DESCRIPTION
Due to update of elRte plugin elFinder now can not load requested file (plugins/elrte/js/jquery-ui-1.8.13.custom.min.js).
There must be requested new version jquery-ui-1.8.20.custom.min.js.
Fixing path string in code or adding plugin settings for path to jQueryUI required.

Update version number of linking library to meet updated elRte dependence.
